### PR TITLE
Simplify Readme example

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,11 +33,10 @@ use ferris_says::say;
 use std::io::{ stdout, BufWriter };
 
 fn main() {
-    let stdout = stdout();
     let out = b"Hello fellow Rustaceans!";
     let width = 24;
 
-    let mut writer = BufWriter::new(stdout.lock());
+    let mut writer = BufWriter::new(stdout());
     say(out, width, &mut writer).unwrap();
 }
 ```


### PR DESCRIPTION
Not using an explicit lock on stdout but instead having BufWriter lock on flushes is a technique [preferred][1] by the master.

[1]: https://github.com/rust-lang-nursery/cli-wg/pull/86#discussion_r219682762