### PR TITLE
Typo in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Put the following in your `Cargo.toml`:
 
 ```toml
 [dependencies]
-ferris_says = "0.1"
+ferris-says = "0.1"
 ```
 
 Then import the crate with:


### PR DESCRIPTION
As ferris-says is used in the official [Get started](https://www.rust-lang.org/learn/get-started) guide, it might confuse newcomers.