### PR TITLE
Awkward docstring genders the mascot

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -45,7 +45,7 @@ const BUFSIZE: usize = 2048;
 const OFFSET:  usize = 4;
 
 
-/// Have Ferris print out her saying something.
+/// Print out Ferris saying something.
 ///
 /// `input` is a slice of bytes that you want to be written out to somewhere
 ///


### PR DESCRIPTION
According to the "Getting started" guide:

> We refer to Ferris with the pronouns “they,” “them,” etc., rather than with gendered pronouns.

https://www.rust-lang.org/learn/get-started#ferris