### PR TITLE
Introducing ferris-says 0.2.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2,8 +2,11 @@
 # It is not intended for manual editing.
 [[package]]
 name = "ansi_term"
-version = "0.10.2"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "winapi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "atty"
@@ -53,15 +56,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "clap"
-version = "2.29.4"
+version = "2.33.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "ansi_term 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ansi_term 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "atty 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "bitflags 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "strsim 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "textwrap 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "unicode-width 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "strsim 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "textwrap 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicode-width 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "vec_map 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -75,11 +78,13 @@ dependencies = [
 
 [[package]]
 name = "ferris-says"
-version = "0.1.2"
+version = "0.2.0"
 dependencies = [
- "clap 2.29.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "error-chain 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "smallvec 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "textwrap 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicode-width 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -112,7 +117,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "strsim"
-version = "0.7.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -127,15 +132,15 @@ dependencies = [
 
 [[package]]
 name = "textwrap"
-version = "0.9.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "unicode-width 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicode-width 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "unicode-width"
-version = "0.1.4"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -163,24 +168,24 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [metadata]
-"checksum ansi_term 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6b3568b48b7cefa6b8ce125f9bb4989e52fbcc29ebea88df04cc7c5f12f70455"
+"checksum ansi_term 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ee49baf6cb617b853aa8d93bf420db2383fab46d314482ca2803b40d5fde979b"
 "checksum atty 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "8352656fd42c30a0c3c89d26dea01e3b77c0ab2af18230835c15e2e13cd51859"
 "checksum backtrace 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "ebbbf59b1c43eefa8c3ede390fcc36820b4999f7914104015be25025e0d62af2"
 "checksum backtrace-sys 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)" = "44585761d6161b0f57afc49482ab6bd067e4edef48c12a152c237eb0203f7661"
 "checksum bitflags 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b3c30d3802dfb7281680d6285f2ccdaa8c2d8fee41f93805dba5c4cf50dc23cf"
 "checksum cc 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "deaf9ec656256bb25b404c51ef50097207b9cbb29c933d31f92cae5a8a0ffee0"
 "checksum cfg-if 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "d4c819a1287eb618df47cc647173c5c4c66ba19d888a6e50d605672aed3140de"
-"checksum clap 2.29.4 (registry+https://github.com/rust-lang/crates.io-index)" = "7b8f59bcebcfe4269b09f71dab0da15b355c75916a8f975d3876ce81561893ee"
+"checksum clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5067f5bb2d80ef5d68b4c87db81601f0b75bca627bc2ef76b141d7b846a3c6d9"
 "checksum error-chain 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d9435d864e017c3c6afeac1654189b06cdb491cf2ff73dbf0d73b0f292f42ff8"
 "checksum libc 0.2.36 (registry+https://github.com/rust-lang/crates.io-index)" = "1e5d97d6708edaa407429faa671b942dc0f2727222fb6b6539bf1db936e4b121"
 "checksum redox_syscall 0.1.37 (registry+https://github.com/rust-lang/crates.io-index)" = "0d92eecebad22b767915e4d529f89f28ee96dbbf5a4810d2b844373f136417fd"
 "checksum redox_termios 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7e891cfe48e9100a70a3b6eb652fef28920c117d366339687bd5576160db0f76"
 "checksum rustc-demangle 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "aee45432acc62f7b9a108cc054142dac51f979e69e71ddce7d6fc7adf29e817e"
 "checksum smallvec 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)" = "ee4f357e8cd37bf8822e1b964e96fd39e2cb5a0424f8aaa284ccaccc2162411c"
-"checksum strsim 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "bb4f380125926a99e52bc279241539c018323fab05ad6368b56f93d9369ff550"
+"checksum strsim 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
 "checksum termion 1.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "689a3bdfaab439fd92bc87df5c4c78417d3cbe537487274e9b0b2dce76e92096"
-"checksum textwrap 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c0b59b6b4b44d867f1370ef1bd91bfb262bf07bf0ae65c202ea2fbc16153b693"
-"checksum unicode-width 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "bf3a113775714a22dcb774d8ea3655c53a32debae63a063acc00a91cc586245f"
+"checksum textwrap 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
+"checksum unicode-width 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "caaa9d531767d1ff2150b9332433f32a24622147e5ebb1f26409d5da67afd479"
 "checksum vec_map 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "887b5b631c2ad01628bbbaa7dd4c869f80d3186688f8d0b6f58774fbe324988c"
 "checksum winapi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "04e3bd221fcbe8a271359c04f21a76db7d0c6028862d1bb5512d85e1e2eb5bb3"
 "checksum winapi-i686-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ferris-says"
-version = "0.1.2"
+version = "0.2.0"
 authors = ["Michael Gattozzi <mgattozzi@gmail.com>"]
 description = "A Rust flavored replacement for the classic cowsay"
 documentation = "https://docs.rs/ferris-says"
@@ -35,3 +35,5 @@ clippy = []
 smallvec = "0.4"
 clap = "2.25"
 error-chain = "0.10"
+textwrap = "0.11.0"
+unicode-width = "0.1.7"

--- a/README.md
+++ b/README.md
@@ -44,15 +44,15 @@ fn main() {
 This will print out this when run:
 
 ```plain
-----------------------------
-| Hello fellow Rustaceans! |
-----------------------------
-              \
-               \
-                 _~^~^~_
-             \) /  o o  \ (/
-               '_   -   _'
-               / '-----' \
+ __________________________
+< Hello fellow Rustaceans! >
+ --------------------------
+        \
+         \
+            _~^~^~_
+        \) /  o o  \ (/
+          '_   -   _'
+          / '-----' \
 ```
 
 ## How to use the binary
@@ -61,21 +61,42 @@ The binary version is called `fsays`. It reads input from `stdin` and prints it
 out to the console.
 
 ```bash
-echo 'Hello fellow Rustaceans!' | fsays --width 24
+fsays 'Hello fellow Rustaceans!'
 ```
 
 This will print out this when run:
 
 ```plain
-----------------------------
-| Hello fellow Rustaceans! |
-----------------------------
-              \
-               \
-                 _~^~^~_
-             \) /  o o  \ (/
-               '_   -   _'
-               / '-----' \
+ __________________________
+< Hello fellow Rustaceans! >
+ --------------------------
+        \
+         \
+            _~^~^~_
+        \) /  o o  \ (/
+          '_   -   _'
+          / '-----' \
+```
+
+A width can also be specified, if desired.
+
+```bash
+fsays --width 12 'Hello fellow Rustaceans!'
+```
+
+will result in the following output:
+
+```plain
+ ______________
+/ Hello fellow \
+\ Rustaceans!  /
+ --------------
+        \
+         \
+            _~^~^~_
+        \) /  o o  \ (/
+          '_   -   _'
+          / '-----' \
 ```
 
 You can also use multiple files as input by using the `-f`/`--files` flag!

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -1,25 +1,25 @@
 #![recursion_limit = "1024"]
 
-extern crate ferris_says;
 extern crate clap;
-#[macro_use] extern crate error_chain;
+extern crate ferris_says;
+#[macro_use]
+extern crate error_chain;
 
+use clap::{App, Arg};
 use ferris_says::*;
-use clap::{ Arg, App };
-use std::io::{ stderr, stdin, stdout, BufWriter, BufReader, Read, Write };
-use std::process::exit;
 use std::fs::File;
+use std::io::{stderr, stdin, stdout, BufReader, BufWriter, Read, Write};
+use std::process::exit;
 
-error_chain!{}
+error_chain! {}
 
 // Constants used for err messages
-const ARGS:   &str = "Invalid argument passed to fsays caused an error";
-const INPUT:  &str = "Failed to read input to the program";
+const ARGS: &str = "Invalid argument passed to fsays caused an error";
+const INPUT: &str = "Failed to read input to the program";
 const STDOUT: &str = "Failed to write stdout";
 const STDERR: &str = "Failed to write stderr";
 
 fn main() {
-
     if let Err(ref e) = run() {
         let stderr = &mut stderr();
 
@@ -35,41 +35,49 @@ fn main() {
 
         exit(1);
     }
-
 }
 
 fn run() -> Result<()> {
     let args = App::new("Ferris Says")
-                    .version("0.1")
-                    .author("Michael Gattozzi <mgattozzi@gmail.com>")
-                    .about("Prints out input text with Ferris the Rustacean")
-                    .arg(Arg::with_name("FILES")
-                        .long("files")
-                        .short("f")
-                        .help("Sets the input files to use")
-                        .required(false)
-                        .takes_value(true)
-                        .multiple(true))
-                    .arg(Arg::with_name("WIDTH")
-                        .long("width")
-                        .short("w")
-                        .help("Sets the width of the text box")
-                        .takes_value(true)
-                        .required(false))
-                    .get_matches();
+        .version("0.1")
+        .author("Michael Gattozzi <mgattozzi@gmail.com>")
+        .about("Prints out input text with Ferris the Rustacean")
+        .arg(
+            Arg::with_name("FILES")
+                .long("files")
+                .short("f")
+                .help("Sets the input files to use")
+                .required(false)
+                .takes_value(true)
+                .multiple(true),
+        )
+        .arg(
+            Arg::with_name("WIDTH")
+                .long("width")
+                .short("w")
+                .help("Sets the width of the text box")
+                .takes_value(true)
+                .default_value("40")
+                .required(false),
+        )
+        .arg(
+            Arg::with_name("TEXT")
+                .required(false)
+                .multiple(true)
+                .hidden(true),
+        )
+        .get_matches();
 
-    let width = args.value_of("WIDTH")
-                    .unwrap_or("50")
-                    .parse()
-                    .chain_err(|| ARGS)?;
+    let width = args.value_of("WIDTH").unwrap().parse().chain_err(|| ARGS)?;
 
     let stdin = stdin();
     let stdout = stdout();
 
+    let mut writer = BufWriter::new(stdout.lock());
+
     if let Some(files) = args.values_of("FILES") {
         // Read in files and say them with Ferris
         let reader = files
-            .into_iter()
             .map(|i| {
                 let reader = BufReader::new(File::open(i).chain_err(|| INPUT)?);
                 Ok(reader
@@ -84,31 +92,30 @@ fn run() -> Result<()> {
                     })?)
             })
             .collect::<Vec<Result<Vec<u8>>>>();
-
-        let mut writer = BufWriter::new(stdout.lock());
         for i in reader {
-            say(&i?, width, &mut writer)
-                .chain_err(|| STDOUT)?;
+            say(&i?, width, &mut writer).chain_err(|| STDOUT)?;
         }
 
         Ok(())
+    } else if let Some(other_args) = args.values_of("TEXT") {
+        let s = other_args.collect::<Vec<&str>>().join(" ");
+        say(s.as_bytes(), width, &mut writer).chain_err(|| STDOUT)?;
 
+        Ok(())
     } else {
-
-        let reader = BufReader::new(stdin.lock())
-            .bytes()
-            .fold(Ok(Vec::new()), |a: Result<Vec<u8>>, b| {
+        let reader = BufReader::new(stdin.lock()).bytes().fold(
+            Ok(Vec::new()),
+            |a: Result<Vec<u8>>, b| {
                 if let Ok(mut a) = a {
                     a.push(b.chain_err(|| INPUT)?);
                     Ok(a)
                 } else {
                     a
                 }
-            })?;
-        let mut writer = BufWriter::new(stdout.lock());
-        say(&reader, width, &mut writer)
-            .chain_err(|| STDOUT)
+            },
+        )?;
+        say(&reader, width, &mut writer).chain_err(|| STDOUT)?;
 
+        Ok(())
     }
-
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,55 +1,54 @@
 extern crate smallvec;
+extern crate textwrap;
+extern crate unicode_width;
 
 use smallvec::*;
-use std::io::{ Write, Result };
+use std::io::{Result, Write};
 use std::iter::repeat;
+use std::str;
+use textwrap::fill;
+use unicode_width::UnicodeWidthStr;
 
 // Constants! :D
-const ENDSL:   &[u8] = b"| ";
-const ENDSR:   &[u8] = b" |\n";
+const ENDSL: &[u8] = b"| ";
+const ENDSR: &[u8] = b" |\n";
 #[cfg(not(feature = "clippy"))]
-const FERRIS:  &[u8] = br#"
-              \
-               \
-                  _~^~^~_
-              \) /  o o  \ (/
-                '_   -   _'
-                / '-----' \
+const FERRIS: &[u8] = br#"
+        \
+         \
+            _~^~^~_
+        \) /  o o  \ (/
+          '_   -   _'
+          / '-----' \
 "#;
+
 #[cfg(feature = "clippy")]
-const CLIPPY:  &[u8] = br#"
-              \
-               \
-                  __
-                 /  \
-                 |  |
-                 @  @
-                 |  |
-                 || |/
-                 || ||
-                 |\_/|
-                 \___/
+const CLIPPY: &[u8] = br#"
+        \
+         \
+            __
+           /  \
+           |  |
+           @  @
+           |  |
+           || |/
+           || ||
+           |\_/|
+           \___/
 "#;
-const NEWLINE: u8 = '\n' as u8;
-const SPACE:   u8  = ' ' as u8;
-const DASH:    u8  = '-' as u8;
+const NEWLINE: u8 = b'\n';
+const DASH: u8 = b'-';
+const UNDERSCORE: u8 = b'_';
 
 // A decent number for SmallVec's Buffer Size, not too large
 // but also big enough for most inputs
 const BUFSIZE: usize = 2048;
 
-// We need a value to add to the width which includes
-// the length of ENDSL and ENDSR for the proper size
-// calculation of the bar at the top and bottom of the
-// box
-const OFFSET:  usize = 4;
-
-
 /// Print out Ferris saying something.
 ///
 /// `input` is a slice of bytes that you want to be written out to somewhere
 ///
-/// `width` is how wide you want the box that Ferris says something into to be
+/// `max_width` is the maximum width of a line of text before it is wrapped
 ///
 /// `writer` is anywhere that can be written to using the Writer trait like
 /// STDOUT or STDERR
@@ -73,42 +72,70 @@ const OFFSET:  usize = 4;
 /// This will print out:
 ///
 /// ```plain
-/// ----------------------------
-/// | Hello fellow Rustaceans! |
-/// ----------------------------
-///               \
-///                \
-///                   _~^~^~_
-///               \) /  o o  \ (/
-///                 '_   -   _'
-///                 / '-----' \
+///  __________________________
+/// < Hello fellow Rustaceans! >
+///  --------------------------
+///         \
+///          \
+///             _~^~^~_
+///         \) /  o o  \ (/
+///           '_   -   _'
+///           / '-----' \
 /// ```
 
-pub fn say<W>(input: &[u8], width: usize, writer: &mut W) -> Result<()>
-    where W: Write
+pub fn say<W>(input: &[u8], max_width: usize, writer: &mut W) -> Result<()>
+where
+    W: Write,
 {
     // Final output is stored here
     let mut write_buffer = SmallVec::<[u8; BUFSIZE]>::new();
 
-    // The top and bottom bar for the text box is calculated once here
-    let bar_buffer: Vec<u8> = repeat(DASH).take(width + OFFSET).collect();
+    // Let textwrap work its magic
+    let wrapped = fill(unsafe { str::from_utf8_unchecked(input) }, max_width);
 
-    write_buffer.extend_from_slice(&bar_buffer);
+    let lines: Vec<&str> = wrapped.lines().collect();
+
+    let line_count = lines.len();
+    let actual_width = longest_line(&lines);
+
+    let mut top_bar_buffer: Vec<u8> = repeat(UNDERSCORE).take(actual_width + 2).collect();
+    top_bar_buffer.insert(0, b' ');
+
+    let mut bottom_bar_buffer: Vec<u8> = repeat(DASH).take(actual_width + 2).collect();
+    bottom_bar_buffer.insert(0, b' ');
+
+    write_buffer.extend_from_slice(&top_bar_buffer);
     write_buffer.push(NEWLINE);
-    for i in input.split(|x| *x == '\n' as u8) {
-        for j in i.chunks(width) {
+
+    for (current_line, line) in lines.into_iter().enumerate() {
+        if line_count == 1 {
+            write_buffer.extend_from_slice(b"< ");
+        } else if current_line == 0 {
+            write_buffer.extend_from_slice(b"/ ");
+        } else if current_line == line_count - 1 {
+            write_buffer.extend_from_slice(b"\\ ");
+        } else {
             write_buffer.extend_from_slice(ENDSL);
-            write_buffer.extend_from_slice(j);
-
-            for _ in 0 .. width - j.len() {
-                write_buffer.push(SPACE);
-            }
-
-            write_buffer.extend_from_slice(ENDSR);
         }
 
+        let line_len = UnicodeWidthStr::width(line);
+        write_buffer.extend_from_slice(line.as_bytes());
+        for _i in line_len..actual_width {
+            write_buffer.extend_from_slice(b" ");
+        }
+
+        if line_count == 1 {
+            write_buffer.extend_from_slice(b" >\n");
+        } else if current_line == 0 {
+            write_buffer.extend_from_slice(b" \\\n");
+        } else if current_line == line_count - 1 {
+            write_buffer.extend_from_slice(b" /\n");
+        } else {
+            write_buffer.extend_from_slice(ENDSR);
+        }
     }
-    write_buffer.extend_from_slice(&bar_buffer);
+
+    write_buffer.extend_from_slice(&bottom_bar_buffer);
     #[cfg(feature = "clippy")]
     write_buffer.extend_from_slice(CLIPPY);
     #[cfg(not(feature = "clippy"))]
@@ -116,4 +143,15 @@ pub fn say<W>(input: &[u8], width: usize, writer: &mut W) -> Result<()>
     writer.write_all(&write_buffer)?;
 
     Ok(())
+}
+
+fn longest_line(lines: &[&str]) -> usize {
+    let mut max_width = 0;
+    for line in lines {
+        let line_width = UnicodeWidthStr::width(line.to_owned());
+        if line_width > max_width {
+            max_width = line_width;
+        }
+    }
+    max_width
 }

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -1,0 +1,157 @@
+extern crate ferris_says;
+
+use ferris_says::say;
+
+// Default width when running the binary
+const DEFAULT_WIDTH: usize = 40;
+
+#[test]
+fn hello_fellow_rustaceans_width_24() -> Result<(), ()> {
+    //Hello fellow Rustaceans!
+    let expected = br#"
+ __________________________
+< Hello fellow Rustaceans! >
+ --------------------------
+        \
+         \
+            _~^~^~_
+        \) /  o o  \ (/
+          '_   -   _'
+          / '-----' \
+"#;
+
+    let input = b"Hello fellow Rustaceans!";
+    let width = 24;
+
+    let mut vec = Vec::new();
+
+    say(input, width, &mut vec).unwrap();
+
+    let actual = std::str::from_utf8(&vec).unwrap();
+
+    assert_eq!(std::str::from_utf8(&expected[1..]).unwrap(), actual);
+    Ok(())
+}
+
+#[test]
+fn hello_fellow_rustaceans_width_12() -> Result<(), ()> {
+    //Hello fellow Rustaceans!
+    let expected = br#"
+ ______________
+/ Hello fellow \
+\ Rustaceans!  /
+ --------------
+        \
+         \
+            _~^~^~_
+        \) /  o o  \ (/
+          '_   -   _'
+          / '-----' \
+"#;
+
+    let input = b"Hello fellow Rustaceans!";
+    let width = 12;
+
+    let mut vec = Vec::new();
+
+    say(input, width, &mut vec).unwrap();
+
+    let actual = std::str::from_utf8(&vec).unwrap();
+
+    assert_eq!(std::str::from_utf8(&expected[1..]).unwrap(), actual);
+    Ok(())
+}
+
+#[test]
+fn hello_fellow_rustaceans_width_6() -> Result<(), ()> {
+    //Hello fellow Rustaceans!
+    let expected = br#"
+ ________
+/ Hello  \
+| fellow |
+| Rustac |
+\ eans!  /
+ --------
+        \
+         \
+            _~^~^~_
+        \) /  o o  \ (/
+          '_   -   _'
+          / '-----' \
+"#;
+
+    let input = b"Hello fellow Rustaceans!";
+    let width = 6;
+
+    let mut vec = Vec::new();
+
+    say(input, width, &mut vec).unwrap();
+
+    let actual = std::str::from_utf8(&vec).unwrap();
+
+    assert_eq!(std::str::from_utf8(&expected[1..]).unwrap(), actual);
+    Ok(())
+}
+
+#[test]
+fn hello_fellow_rustaceans_width_3() -> Result<(), ()> {
+    //Hello fellow Rustaceans!
+    let expected = br#"
+ _____
+/ Hel \
+| lo  |
+| fel |
+| low |
+| Rus |
+| tac |
+| ean |
+\ s!  /
+ -----
+        \
+         \
+            _~^~^~_
+        \) /  o o  \ (/
+          '_   -   _'
+          / '-----' \
+"#;
+
+    let input = b"Hello fellow Rustaceans!";
+    let width = 3;
+
+    let mut vec = Vec::new();
+
+    say(input, width, &mut vec).unwrap();
+
+    let actual = std::str::from_utf8(&vec).unwrap();
+
+    assert_eq!(std::str::from_utf8(&expected[1..]).unwrap(), actual);
+    Ok(())
+}
+
+#[test]
+fn multibyte_string() -> Result<(), ()> {
+    let expected = concat!(
+        " ____________\n",
+        "< 突然の死👻 >\n",
+        " ------------\n",
+        r#"        \
+         \
+            _~^~^~_
+        \) /  o o  \ (/
+          '_   -   _'
+          / '-----' \
+"#
+    );
+
+    let input = "突然の死👻";
+    let width = DEFAULT_WIDTH;
+
+    let mut vec = Vec::new();
+
+    say(input.as_bytes(), width, &mut vec).unwrap();
+
+    let actual = std::str::from_utf8(&vec).unwrap();
+
+    assert_eq!(std::str::from_utf8(&expected.as_bytes()).unwrap(), actual);
+    Ok(())
+}


### PR DESCRIPTION
I've recently been toying with Rust and came across `ferris-says`.  I liked the concept and was inspired to work on a few enhancements.  Highlights are below:
 - Output more closely matches `cowsay`
 - Additional arguments can be provided to the command as an alternative to standard input
 - Graceful handling of multi-byte characters (should fix #2)
 - Addition of integration tests

Given the scope of changes I've tentatively deemed this version 0.2.0.  I'll defer to your input and guidance on versioning.  I have a few other ideas in mind, mostly providing parity with `cowsay/cowthink` but this is sufficient for now.  :-)

I look forward to your feedback and thoughts.  Thanks!