### PR TITLE
Update textwrap to version 0.13.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,5 +35,5 @@ clippy = []
 smallvec = "0.4"
 clap = "2.25"
 error-chain = "0.10"
-textwrap = "0.11.0"
+textwrap = "0.13"
 unicode-width = "0.1.7"


### PR DESCRIPTION
The newly released version has a new wrapping algorithm which tries to optimize output in narrow columns. Please see https://github.com/mgeisler/textwrap/releases/tag/0.13.0.