### PR TITLE
Fix unsoundness on invalid utf-8 inputs

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -91,7 +91,10 @@ where
     let mut write_buffer = SmallVec::<[u8; BUFSIZE]>::new();
 
     // Let textwrap work its magic
-    let wrapped = fill(unsafe { str::from_utf8_unchecked(input) }, max_width);
+    let wrapped = fill(
+        str::from_utf8(input).map_err(|_| std::io::ErrorKind::InvalidData)?,
+        max_width,
+    );
 
     let lines: Vec<&str> = wrapped.lines().collect();
 


### PR DESCRIPTION
Previously, unchecked user input bytes were passed into
`str::from_utf8_unchecked`, which was unsound as it was within a safe
function. It's been revised to check the user input and fail if there's
invalid input.

For a file with fun contents of broken UTF-8 to test with, see <https://www.cl.cam.ac.uk/~mgk25/ucs/examples/UTF-8-test.txt>