### PR TITLE
Demonstration for supporting `bin target` fsays

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,11 @@ appveyor = { repository = "mgattozzi/ferris-says", branch = "master", service = 
 [lib]
 name = "ferris_says"
 
+[[bin]]
+name = "fsays"
+path = "fsays/src/main.rs"
+
+
 [features]
 clippy = []
 


### PR DESCRIPTION
Hi! I'd love to be able to intall `fsays` using cargo but...

I'm struggling to understand whether there is a way to install the `fsays` binary using `cargo install --bin`. At first glance in the [Cargo Book](https://doc.rust-lang.org/cargo/commands/cargo-install.html) it seems that there might be a way to do it with `cargo install ferris-says --bin fsays` but that fails because there is not a bin target named fsays.

```
❯❯ cargo install ferris-says --bin fsays
    Updating crates.io index
  Installing ferris-says v0.2.1
error: failed to compile `ferris-says v0.2.1`, intermediate artifacts can be found at `/home/dlevin/nobackup/cargo`

Caused by:
  no bin target named `fsays`
  ```

To your knowledge, is this the right way to go about supporting `cargo install` for `fsays`?

Alternately, if there's no way to achieve installing fsays using `cargo install` I'd be happy to update the [README](https://github.com/mgattozzi/ferris-says#how-to-use-the-binary) with a sentence or two explaining that the user must clone the git repo and invoke `cargo install --path .` or something like that.