### PR TITLE
README: Add installation snippet for fsays

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,8 +56,13 @@ This will print out this when run:
 
 ## How to use the binary
 
-The binary version is called `fsays`. It reads input from `stdin` and prints it
-out to the console.
+The binary version is called `fsays` and can be installed with `cargo install`:
+
+```bash
+cargo install fsays
+```
+
+It reads input from `stdin` and prints it out to the console.
 
 ```bash
 fsays 'Hello fellow Rustaceans!'


### PR DESCRIPTION
Hey, I personally think that `fsays` should have more visibility itself than `ferris-says`.

The README wasn't explaining how to install it, I added the line

```bash
cargo install fsays
```

Would also suggest adding a crates.io link to it, or a README in the `fsays/` folder so that crates.io/crates/fsays have some description.