### PR TITLE
bump smallvec version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ name = "ferris_says"
 clippy = []
 
 [dependencies]
-smallvec = "0.4"
+smallvec = "1.9.0"
 textwrap = "0.13"
 unicode-width = "0.1.7"
 


### PR DESCRIPTION
This PR bumps the version of the `smallvec` dependency to a newer version.

When running the tests of this crate under miri, it reports Undefined Behavior.
```rs
error: Undefined Behavior: constructing invalid value at .value[0]: encountered uninitialized bytes
   --> /home/timo/.cargo/registry/src/github.com-1ecc6299db9ec823/smallvec-0.4.5/lib.rs:271:39
    |
271 |                 data: Inline { array: mem::uninitialized() },
    |                                       ^^^^^^^^^^^^^^^^^^^^ constructing invalid value at .value[0]: encountered uninitialized bytes
    |
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
    = note: backtrace:
    = note: inside `smallvec::SmallVec::<[u8; 2048]>::new` at /home/timo/.cargo/registry/src/github.com-1ecc6299db9ec823/smallvec-0.4.5/lib.rs:271:39
note: inside `ferris_says::say::<std::vec::Vec<u8>>` at /home/timo/ferris-says/src/lib.rs:91:28
```
This comes from the smallvec dependency and is fixed in newer versions.