### PR TITLE
Take generic writer by value

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -46,7 +46,7 @@ const BUFSIZE: usize = 2048;
 
 /// Print out Ferris saying something.
 ///
-/// `input` is a slice of bytes that you want to be written out to somewhere
+/// `input` is a string slice that you want to be written out to somewhere
 ///
 /// `max_width` is the maximum width of a line of text before it is wrapped
 ///
@@ -62,7 +62,7 @@ const BUFSIZE: usize = 2048;
 /// use std::io::{ stdout, BufWriter };
 ///
 /// let stdout = stdout();
-/// let out = b"Hello fellow Rustaceans!";
+/// let out = "Hello fellow Rustaceans!";
 /// let width = 24;
 ///
 /// let mut writer = BufWriter::new(stdout.lock());
@@ -83,7 +83,7 @@ const BUFSIZE: usize = 2048;
 ///           / '-----' \
 /// ```
 
-pub fn say<W>(input: &[u8], max_width: usize, writer: &mut W) -> Result<()>
+pub fn say<W>(input: &str, max_width: usize, writer: &mut W) -> Result<()>
 where
     W: Write,
 {
@@ -91,10 +91,7 @@ where
     let mut write_buffer = SmallVec::<[u8; BUFSIZE]>::new();
 
     // Let textwrap work its magic
-    let wrapped = fill(
-        str::from_utf8(input).map_err(|_| std::io::ErrorKind::InvalidData)?,
-        max_width,
-    );
+    let wrapped = fill(input, max_width);
 
     let lines: Vec<&str> = wrapped.lines().collect();
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,8 +4,6 @@ extern crate unicode_width;
 
 use smallvec::*;
 use std::io::{Result, Write};
-use std::iter::repeat;
-use std::str;
 use textwrap::fill;
 use unicode_width::UnicodeWidthStr;
 
@@ -39,6 +37,7 @@ const CLIPPY: &[u8] = br#"
 const NEWLINE: u8 = b'\n';
 const DASH: u8 = b'-';
 const UNDERSCORE: u8 = b'_';
+const SPACE: u8 = b' ';
 
 // A decent number for SmallVec's Buffer Size, not too large
 // but also big enough for most inputs
@@ -82,7 +81,6 @@ const BUFSIZE: usize = 2048;
 ///           '_   -   _'
 ///           / '-----' \
 /// ```
-
 pub fn say<W>(input: &str, max_width: usize, writer: &mut W) -> Result<()>
 where
     W: Write,
@@ -98,21 +96,20 @@ where
     let line_count = lines.len();
     let actual_width = longest_line(&lines);
 
-    let mut top_bar_buffer: Vec<u8> = repeat(UNDERSCORE).take(actual_width + 2).collect();
-    top_bar_buffer.insert(0, b' ');
-
-    let mut bottom_bar_buffer: Vec<u8> = repeat(DASH).take(actual_width + 2).collect();
-    bottom_bar_buffer.insert(0, b' ');
-
-    write_buffer.extend_from_slice(&top_bar_buffer);
+    // top box border
+    write_buffer.push(SPACE);
+    for _ in 0..(actual_width + 2) {
+        write_buffer.push(UNDERSCORE);
+    }
     write_buffer.push(NEWLINE);
 
-    for (current_line, line) in lines.into_iter().enumerate() {
+    // inner message
+    for (i, line) in lines.into_iter().enumerate() {
         if line_count == 1 {
             write_buffer.extend_from_slice(b"< ");
-        } else if current_line == 0 {
+        } else if i == 0 {
             write_buffer.extend_from_slice(b"/ ");
-        } else if current_line == line_count - 1 {
+        } else if i == line_count - 1 {
             write_buffer.extend_from_slice(b"\\ ");
         } else {
             write_buffer.extend_from_slice(ENDSL);
@@ -120,29 +117,34 @@ where
 
         let line_len = UnicodeWidthStr::width(line);
         write_buffer.extend_from_slice(line.as_bytes());
-        for _i in line_len..actual_width {
-            write_buffer.extend_from_slice(b" ");
+        for _ in line_len..actual_width {
+            write_buffer.push(SPACE);
         }
 
         if line_count == 1 {
             write_buffer.extend_from_slice(b" >\n");
-        } else if current_line == 0 {
+        } else if i == 0 {
             write_buffer.extend_from_slice(b" \\\n");
-        } else if current_line == line_count - 1 {
+        } else if i == line_count - 1 {
             write_buffer.extend_from_slice(b" /\n");
         } else {
             write_buffer.extend_from_slice(ENDSR);
         }
     }
 
-    write_buffer.extend_from_slice(&bottom_bar_buffer);
+    // bottom box border
+    write_buffer.push(SPACE);
+    for _ in 0..(actual_width + 2) {
+        write_buffer.push(DASH);
+    }
+
+    // mascot
     #[cfg(feature = "clippy")]
     write_buffer.extend_from_slice(CLIPPY);
     #[cfg(not(feature = "clippy"))]
     write_buffer.extend_from_slice(FERRIS);
-    writer.write_all(&write_buffer)?;
 
-    Ok(())
+    writer.write_all(&write_buffer)
 }
 
 fn longest_line(lines: &[&str]) -> usize {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -149,12 +149,9 @@ where
 }
 
 fn longest_line(lines: &[&str]) -> usize {
-    let mut max_width = 0;
-    for line in lines {
-        let line_width = UnicodeWidthStr::width(line.to_owned());
-        if line_width > max_width {
-            max_width = line_width;
-        }
-    }
-    max_width
+    lines
+        .iter()
+        .map(|line| UnicodeWidthStr::width(*line))
+        .max()
+        .unwrap_or(0)
 }

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -38,7 +38,7 @@ fn hello_fellow_rustaceans_width_24() -> Result<(), ()> {
            \___/
 "#;
 
-    let input = b"Hello fellow Rustaceans!";
+    let input = "Hello fellow Rustaceans!";
     let width = 24;
 
     let mut vec = Vec::new();
@@ -86,7 +86,7 @@ fn hello_fellow_rustaceans_width_12() -> Result<(), ()> {
            \___/
 "#;
 
-    let input = b"Hello fellow Rustaceans!";
+    let input = "Hello fellow Rustaceans!";
     let width = 12;
 
     let mut vec = Vec::new();
@@ -138,7 +138,7 @@ fn hello_fellow_rustaceans_width_6() -> Result<(), ()> {
            \___/
 "#;
 
-    let input = b"Hello fellow Rustaceans!";
+    let input = "Hello fellow Rustaceans!";
     let width = 6;
 
     let mut vec = Vec::new();
@@ -198,7 +198,7 @@ fn hello_fellow_rustaceans_width_3() -> Result<(), ()> {
            \___/
 "#;
 
-    let input = b"Hello fellow Rustaceans!";
+    let input = "Hello fellow Rustaceans!";
     let width = 3;
 
     let mut vec = Vec::new();
@@ -250,7 +250,7 @@ fn multibyte_string() -> Result<(), ()> {
 
     let mut vec = Vec::new();
 
-    say(input.as_bytes(), width, &mut vec).unwrap();
+    say(input, width, &mut vec).unwrap();
 
     let actual = std::str::from_utf8(&vec).unwrap();
 

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -9,7 +9,7 @@ const DEFAULT_WIDTH: usize = 40;
 fn hello_fellow_rustaceans_width_24() -> Result<(), ()> {
     //Hello fellow Rustaceans!
     #[cfg(not(feature = "clippy"))]
-    let expected = br#"
+    let expected = r#"
  __________________________
 < Hello fellow Rustaceans! >
  --------------------------
@@ -21,7 +21,7 @@ fn hello_fellow_rustaceans_width_24() -> Result<(), ()> {
           / '-----' \
 "#;
     #[cfg(feature = "clippy")]
-    let expected = br#"
+    let expected = r#"
  __________________________
 < Hello fellow Rustaceans! >
  --------------------------
@@ -47,7 +47,7 @@ fn hello_fellow_rustaceans_width_24() -> Result<(), ()> {
 
     let actual = std::str::from_utf8(&vec).unwrap();
 
-    assert_eq!(std::str::from_utf8(&expected[1..]).unwrap(), actual);
+    assert_eq!(&expected[1..], actual);
     Ok(())
 }
 
@@ -55,7 +55,7 @@ fn hello_fellow_rustaceans_width_24() -> Result<(), ()> {
 fn hello_fellow_rustaceans_width_12() -> Result<(), ()> {
     //Hello fellow Rustaceans!
     #[cfg(not(feature = "clippy"))]
-    let expected = br#"
+    let expected = r#"
  ______________
 / Hello fellow \
 \ Rustaceans!  /
@@ -68,7 +68,7 @@ fn hello_fellow_rustaceans_width_12() -> Result<(), ()> {
           / '-----' \
 "#;
     #[cfg(feature = "clippy")]
-    let expected = br#"
+    let expected = r#"
  ______________
 / Hello fellow \
 \ Rustaceans!  /
@@ -95,7 +95,7 @@ fn hello_fellow_rustaceans_width_12() -> Result<(), ()> {
 
     let actual = std::str::from_utf8(&vec).unwrap();
 
-    assert_eq!(std::str::from_utf8(&expected[1..]).unwrap(), actual);
+    assert_eq!(&expected[1..], actual);
     Ok(())
 }
 
@@ -103,7 +103,7 @@ fn hello_fellow_rustaceans_width_12() -> Result<(), ()> {
 fn hello_fellow_rustaceans_width_6() -> Result<(), ()> {
     //Hello fellow Rustaceans!
     #[cfg(not(feature = "clippy"))]
-    let expected = br#"
+    let expected = r#"
  ________
 / Hello  \
 | fellow |
@@ -118,7 +118,7 @@ fn hello_fellow_rustaceans_width_6() -> Result<(), ()> {
           / '-----' \
 "#;
     #[cfg(feature = "clippy")]
-    let expected = br#"
+    let expected = r#"
  ________
 / Hello  \
 | fellow |
@@ -147,7 +147,7 @@ fn hello_fellow_rustaceans_width_6() -> Result<(), ()> {
 
     let actual = std::str::from_utf8(&vec).unwrap();
 
-    assert_eq!(std::str::from_utf8(&expected[1..]).unwrap(), actual);
+    assert_eq!(&expected[1..], actual);
     Ok(())
 }
 
@@ -155,7 +155,7 @@ fn hello_fellow_rustaceans_width_6() -> Result<(), ()> {
 fn hello_fellow_rustaceans_width_3() -> Result<(), ()> {
     //Hello fellow Rustaceans!
     #[cfg(not(feature = "clippy"))]
-    let expected = br#"
+    let expected = r#"
  _____
 / Hel \
 | lo  |
@@ -174,7 +174,7 @@ fn hello_fellow_rustaceans_width_3() -> Result<(), ()> {
           / '-----' \
 "#;
     #[cfg(feature = "clippy")]
-    let expected = br#"
+    let expected = r#"
  _____
 / Hel \
 | lo  |
@@ -207,31 +207,30 @@ fn hello_fellow_rustaceans_width_3() -> Result<(), ()> {
 
     let actual = std::str::from_utf8(&vec).unwrap();
 
-    assert_eq!(std::str::from_utf8(&expected[1..]).unwrap(), actual);
+    assert_eq!(&expected[1..], actual);
     Ok(())
 }
 
 #[test]
 fn multibyte_string() -> Result<(), ()> {
     #[cfg(not(feature = "clippy"))]
-    let expected = concat!(
-        " ____________\n",
-        "< 突然の死👻 >\n",
-        " ------------\n",
-        r#"        \
+    let expected = r#"
+ ____________
+< 突然の死👻 >
+ ------------
+        \
          \
             _~^~^~_
         \) /  o o  \ (/
           '_   -   _'
           / '-----' \
-"#
-    );
+"#;
     #[cfg(feature = "clippy")]
-    let expected = concat!(
-        " ____________\n",
-        "< 突然の死👻 >\n",
-        " ------------\n",
-        r#"        \
+    let expected = r#"
+ ____________
+< 突然の死👻 >
+ ------------
+        \
          \
             __
            /  \
@@ -242,8 +241,7 @@ fn multibyte_string() -> Result<(), ()> {
            || ||
            |\_/|
            \___/
-"#
-    );
+"#;
 
     let input = "突然の死👻";
     let width = DEFAULT_WIDTH;
@@ -254,6 +252,6 @@ fn multibyte_string() -> Result<(), ()> {
 
     let actual = std::str::from_utf8(&vec).unwrap();
 
-    assert_eq!(std::str::from_utf8(&expected.as_bytes()).unwrap(), actual);
+    assert_eq!(&expected[1..], actual);
     Ok(())
 }


### PR DESCRIPTION
According to the [Rust API Guidelines](https://rust-lang.github.io/api-guidelines/interoperability.html#generic-readerwriter-functions-take-r-read-and-w-write-by-value-c-rw-value) generic writers should be taken by value and not by exclusive reference.