### PR TITLE
doc(example): fix wrong type

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ use ferris_says::say;
 use std::io::{ stdout, BufWriter };
 
 fn main() {
-    let out = b"Hello fellow Rustaceans!";
+    let out = "Hello fellow Rustaceans!";
     let width = 24;
 
     let mut writer = BufWriter::new(stdout());


### PR DESCRIPTION
```rs
  let out = "Hello fellow Rustaceans!"; // out is '&str'
```


cargo run successfully.
<img width="785" alt="image" src="https://user-images.githubusercontent.com/12870715/200045421-b27ba06c-1ae3-47fc-89b4-7167eefa262e.png">
