### PR TITLE
docs: update outdated library part in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,13 @@ Put the following in your `Cargo.toml`:
 
 ```toml
 [dependencies]
-ferris-says = "0.2"
+ferris-says = "0.3.1"
+```
+
+or run:
+
+```sh
+cargo add ferris-says
 ```
 
 Then import the crate with:
@@ -32,7 +38,7 @@ use ferris_says::say;
 use std::io::{ stdout, BufWriter };
 
 fn main() {
-    let out = b"Hello fellow Rustaceans!";
+    let out = "Hello fellow Rustaceans!";
     let width = 24;
 
     let mut writer = BufWriter::new(stdout());


### PR DESCRIPTION
The latest version is 0.3.1, but the library usage is for 0.2

To avoid leaving out update version in README, I add the way of cargo command.

This PR relate the following PR or issue: #32, #36 (I am not sure why this closed in the end).