### PR TITLE
Delete Travis CI and AppVeyor badges from Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,10 +17,6 @@ categories = [
 ]
 license = "MIT/Apache-2.0"
 
-[badges]
-travis-ci = { repository = "mgattozzi/ferris-says", branch = "master" }
-appveyor = { repository = "mgattozzi/ferris-says", branch = "master", service = "github" }
-
 [lib]
 name = "ferris_says"
 


### PR DESCRIPTION
Neither Travis CI nor AppVeyor is building this project.

Furthermore, badges functionality has been deprecated by crates.io since 4 years ago.