### PR TITLE
Delete redundant lib name from Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,9 +21,6 @@ license = "MIT/Apache-2.0"
 travis-ci = { repository = "mgattozzi/ferris-says", branch = "master" }
 appveyor = { repository = "mgattozzi/ferris-says", branch = "master", service = "github" }
 
-[lib]
-name = "ferris_says"
-
 [features]
 clippy = []
 


### PR DESCRIPTION
Cargo computes a default lib name by taking the package name and replacing `-` with `_`. In this case the package name is `ferris-says` so the default lib name is already `ferris_says`.