### PR TITLE
Remove conditional compilation from mascot constants

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,16 +10,7 @@ use unicode_width::UnicodeWidthStr;
 // Constants! :D
 const ENDSL: &[u8] = b"| ";
 const ENDSR: &[u8] = b" |\n";
-const MASCOT: &[u8] = if !cfg!(feature = "clippy") {
-    br#"
-        \
-         \
-            _~^~^~_
-        \) /  o o  \ (/
-          '_   -   _'
-          / '-----' \
-"#
-} else {
+const MASCOT: &[u8] = if cfg!(feature = "clippy") {
     br#"
         \
          \
@@ -32,6 +23,15 @@ const MASCOT: &[u8] = if !cfg!(feature = "clippy") {
            || ||
            |\_/|
            \___/
+"#
+} else {
+    br#"
+        \
+         \
+            _~^~^~_
+        \) /  o o  \ (/
+          '_   -   _'
+          / '-----' \
 "#
 };
 const NEWLINE: u8 = b'\n';

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,7 +11,7 @@ use unicode_width::UnicodeWidthStr;
 const ENDSL: &[u8] = b"| ";
 const ENDSR: &[u8] = b" |\n";
 #[cfg(not(feature = "clippy"))]
-const FERRIS: &[u8] = br#"
+const MASCOT: &[u8] = br#"
         \
          \
             _~^~^~_
@@ -21,7 +21,7 @@ const FERRIS: &[u8] = br#"
 "#;
 
 #[cfg(feature = "clippy")]
-const CLIPPY: &[u8] = br#"
+const MASCOT: &[u8] = br#"
         \
          \
             __
@@ -139,10 +139,7 @@ where
     }
 
     // mascot
-    #[cfg(feature = "clippy")]
-    write_buffer.extend_from_slice(CLIPPY);
-    #[cfg(not(feature = "clippy"))]
-    write_buffer.extend_from_slice(FERRIS);
+    write_buffer.extend_from_slice(MASCOT);
 
     writer.write_all(&write_buffer)
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,18 +10,17 @@ use unicode_width::UnicodeWidthStr;
 // Constants! :D
 const ENDSL: &[u8] = b"| ";
 const ENDSR: &[u8] = b" |\n";
-#[cfg(not(feature = "clippy"))]
-const MASCOT: &[u8] = br#"
+const MASCOT: &[u8] = if !cfg!(feature = "clippy") {
+    br#"
         \
          \
             _~^~^~_
         \) /  o o  \ (/
           '_   -   _'
           / '-----' \
-"#;
-
-#[cfg(feature = "clippy")]
-const MASCOT: &[u8] = br#"
+"#
+} else {
+    br#"
         \
          \
             __
@@ -33,7 +32,8 @@ const MASCOT: &[u8] = br#"
            || ||
            |\_/|
            \___/
-"#;
+"#
+};
 const NEWLINE: u8 = b'\n';
 const DASH: u8 = b'-';
 const UNDERSCORE: u8 = b'_';


### PR DESCRIPTION
Using #[cfg(...)] is not ideal here because it harms compile-time checking. For example, in order to be sure there isn't a type error, one must separately compile with and without "clippy" when making changes to the crate.

Rust supports `if` in constants since version 1.46.0 and it's a better fit for this code.