### PR TITLE
Use SPDX syntax for license expression

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ categories = [
   "command-line-utilities",
   "value-formatting"
 ]
-license = "MIT/Apache-2.0"
+license = "MIT OR Apache-2.0"
 
 [badges]
 travis-ci = { repository = "mgattozzi/ferris-says", branch = "master" }

--- a/fsays/Cargo.toml
+++ b/fsays/Cargo.toml
@@ -15,7 +15,7 @@ categories = [
   "command-line-utilities",
   "value-formatting"
 ]
-license = "MIT/Apache-2.0"
+license = "MIT OR Apache-2.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 


### PR DESCRIPTION
The `license` is supposed to be an SPDX 2.3 license expression. See https://doc.rust-lang.org/1.75.0/cargo/reference/manifest.html#the-license-and-license-file-fields.

SPDX license expressions support AND and OR operators to combine multiple licenses.

Previously multiple licenses could be separated with a `/`, but that usage is deprecated.