### PR TITLE
Update to 2021 edition, removing extern crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 name = "ferris-says"
 version = "0.3.1"
 authors = ["Michael Gattozzi <mgattozzi@gmail.com>"]
+edition = "2021"
 description = "A Rust flavored replacement for the classic cowsay"
 documentation = "https://docs.rs/ferris-says"
 repository = "https://github.com/rust-lang/ferris-says"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,3 @@
-extern crate smallvec;
-extern crate textwrap;
-extern crate unicode_width;
-
 use smallvec::*;
 use std::io::{Result, Write};
 use textwrap::fill;

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -1,5 +1,3 @@
-extern crate ferris_says;
-
 use ferris_says::say;
 
 // Default width when running the binary


### PR DESCRIPTION
Edition 2021 matches the edition you currently get with `cargo new` / `cargo init`, so using this in ferris-says is most likely to be informative to novice users.